### PR TITLE
Feature/datahub cofigure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ datahub --version [-V]
 
 ### Commands
 
+#### get - view or download data from DataHub
+
 ```
 datahub get <resource> [dir]
 
@@ -37,6 +39,20 @@ datahub get {publisher}/{package}/{resource}.[extension]
 # Get data on disk
 datahub get {publisher}/{package}/{resource}.[extension] [my_dir]
 ```
+
+#### configure - set credentials to authenticate for DataHub registry
+
+```
+datahub configure [dir]
+
+# Fill with required info
+datahub configure
+> Username: < your user name >
+> Your access token (input hidden): < your secret token >
+> Server URL: < https://example.com >
+
+```
+Your Configurations will be saved in `~/.datahub/config`
 
 # Tests
 

--- a/bin/datahub.js
+++ b/bin/datahub.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --harmony
 const configure = require('../lib/config.js').configure
 const get = require('../lib/index.js').get
 const program = require('commander')

--- a/bin/datahub.js
+++ b/bin/datahub.js
@@ -6,8 +6,10 @@ const version = require('../package.json').version
 program
   .version(version)
   .usage('<command> [options] ')
-  .description('DataHub CLI')
-  .command('get <package> [dest...]', 'View or Download file from Datahub')
+
+program
+  .command('get <package> [dest]')
+  .description('View or Download file from DataHub')
   .action(function(package, dest) {
     [ publisher, package, resource ] = package.split('/')
     get(publisher, package, resource, dest)

--- a/bin/datahub.js
+++ b/bin/datahub.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env node
+const configure = require('../lib/config.js').configure
 const get = require('../lib/index.js').get
 const program = require('commander')
 const version = require('../package.json').version
@@ -13,6 +14,13 @@ program
   .action(function(package, dest) {
     [ publisher, package, resource ] = package.split('/')
     get(publisher, package, resource, dest)
+  })
+
+program
+  .command('configure [dest]')
+  .description('Set Up DataHub Configurations')
+  .action(function(dest) {
+    configure()
   })
 
 program.parse(process.argv)

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,7 +26,7 @@ for the DataHub registry server.\n`
         message: 'Username should not be empty!',
         required: true
       },
-      accessToke: {
+      accessToken: {
         description: 'Your access token (input hidden)',
         message: 'Access token should not be empty!',
         required: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const ini = require('ini');
+const path = require('path');
+const expandHomeDir = require('expand-home-dir')
+const prompt = require('prompt');
+
+const configDir = expandHomeDir('~/.datahub')
+const defaultServer = 'https://example.com'
+let configFile = path.join(configDir, 'config')
+
+if (!fs.existsSync(configDir)){
+  fs.mkdirSync(configDir);
+}
+
+
+exports.configure = function() {
+  process.stdout.write(
+`Please enter your credentials to authenticate
+for the DataHub registry server.\n`
+  )
+
+  let schema = {
+    properties: {
+      username: {
+        description: 'Username',
+        message: 'Username should not be empty!',
+        required: true
+      },
+      accessToke: {
+        description: 'Your access token (input hidden)',
+        message: 'Access token should not be empty!',
+        required: true,
+        hidden: true
+      },
+      server: {
+        description: 'Server URL',
+        default: defaultServer
+      }
+    }
+  }
+  prompt.message = ''
+  prompt.start()
+  prompt.get(schema, function (err, result) {
+    if (err) {
+      return process.stderr.write(err.message+'\n');
+    }
+    fs.writeFileSync(configFile, ini.stringify(result))
+    process.stdout.write(`Configuration saved to: ${configFile}\n`)
+  })
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,14 +7,13 @@ exports.get = function(publisher, package, resource, dest) {
   let url = `https://bits.datapackaged.com/metadata/${publisher}/${package}/_v/latest/data/${resource}`
   return axios.get(url)
     .then(res => {
-      if (!dest.length) {
+      if (!dest) {
         return process.stdout.write(res.data)
       }
-      let dir = dest[0]
-      let fpath = path.join(dest[0], resource)
+      let fpath = path.join(dest, resource)
       // create path if not exists
-      if (!fs.existsSync(dir)){
-          fs.mkdirSync(dir);
+      if (!fs.existsSync(dest)){
+          fs.mkdirSync(dest);
       }
       fs.writeFileSync(fpath, res.data)
     })

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "dependencies": {
     "axios": "^0.16.1",
     "commander": "^2.9.0",
+    "expand-home-dir": "0.0.3",
+    "ini": "^1.3.4",
+    "prompt": "^1.0.0",
     "tmp": "0.0.31"
   },
   "devDependencies": {

--- a/test/test_lib.js
+++ b/test/test_lib.js
@@ -14,7 +14,7 @@ describe('basic test for lib directory', () => {
   });
 
   it('get() writes in file', (done) => {
-    get('publisher', 'package', 'resource.csv', [tmpobj.name]).then( () => {
+    get('publisher', 'package', 'resource.csv', tmpobj.name).then( () => {
       let exp  = fs.readFileSync('test/fixtures/sample.csv').toString()
       let res = fs.readFileSync(tmpobj.name + '/resource.csv').toString()
       assert.equal(exp, res)
@@ -23,7 +23,7 @@ describe('basic test for lib directory', () => {
   })
 
   it('get() outputs in stdout', () => {
-    get('publisher', 'package', 'resource.csv', [])
+    get('publisher', 'package', 'resource.csv')
     assert.equal(1, 1)
   })
 


### PR DESCRIPTION
PR for `datahub configure` command refs #12 

PR includes functionality and change in `bin/datahub.js` to handle two separate commands

Note: reading for already existing configure is not yet implemented. As think it should go as part of the publish command