### PR TITLE
Identifier parser

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ const prompt = require('prompt');
 const configDir = expandHomeDir('~/.datahub')
 const configFile = path.join(configDir, 'config')
 const defaultServer = 'https://staging.datapackaged.com'
+const defaultBitStore = 'https://bits-staging.datapackaged.com'
 
 if (!fs.existsSync(configDir)){
   fs.mkdirSync(configDir);
@@ -34,6 +35,10 @@ for the DataHub registry server.\n`
       server: {
         description: 'Server URL',
         default: defaultServer
+      },
+      bitStore: {
+        description: 'BitStore URL',
+        default: defaultBitStore
       }
     }
   }
@@ -59,4 +64,5 @@ const readConfig = (configPath=configFile) => {
 module.exports.config = config
 module.exports.configFile = configFile
 module.exports.defaultServer = defaultServer
+module.exports.defaultBitStore = defaultBitStore
 module.exports.readConfig = readConfig

--- a/lib/get.js
+++ b/lib/get.js
@@ -11,7 +11,7 @@ const utils = require('./utils/common')
 
 module.exports.get = async(pkgid) => {
   let start = new Date()
-  const { publisher, name } = utils.parseIdentifier(pkgid)
+  const { publisher, name } = utils.parseIdentifier(pkgid, 'datahub')
   if (!publisher ||  !name ) {
     console.error('Publisher or package name not found. | See data help get')
     process.exit(1)

--- a/lib/get.js
+++ b/lib/get.js
@@ -11,19 +11,19 @@ const utils = require('./utils/common')
 
 module.exports.get = async(pkgid) => {
   let start = new Date()
-  const { publisher, pkg } = utils.parseIdentifier(pkgid)
-  if (!publisher ||  !pkg ) {
+  const { publisher, name } = utils.parseIdentifier(pkgid)
+  if (!publisher ||  !name ) {
     console.error('Publisher or package name not found. | See data help get')
     process.exit(1)
   }
 
-  const dist = checkDestIsEmpty(publisher, pkg)
+  const dist = checkDestIsEmpty(publisher, name)
   if (!dist) {
-    console.error(`${publisher}/${pkg} is not empty!`)
+    console.error(`${publisher}/${name} is not empty!`)
     process.exit(1)
   }
 
-  const metadata = await utils.getMetadata(publisher, pkg)
+  const metadata = await utils.getMetadata(publisher, name)
   const bitStoreUrl = metadata.bitstore_url
   const descriptor = metadata.descriptor
   const filesToDownload = getFilesToDownload(bitStoreUrl, descriptor)
@@ -35,7 +35,7 @@ module.exports.get = async(pkgid) => {
 
   let downloads = []
   filesToDownload.forEach(file => {
-    downloads.push(downloadFile(file.url, file.destPath, publisher, pkg, bar))
+    downloads.push(downloadFile(file.url, file.destPath, publisher, name, bar))
   })
 
   Promise.all(downloads).then(() => {
@@ -48,8 +48,8 @@ module.exports.get = async(pkgid) => {
 
 }
 
-const checkDestIsEmpty = (publisher, pkg) => {
-  let dest = path.join(publisher, pkg)
+const checkDestIsEmpty = (publisher, name) => {
+  let dest = path.join(publisher, name)
   if (!fs.existsSync(dest)){
     return true
   }
@@ -84,7 +84,7 @@ const getFilesToDownload = (bitStoreUrl, descriptor) => {
   return files
 }
 
-const downloadFile = async (bitStoreUrl, dest, publisher, pkg, bar) => {
+const downloadFile = async (bitStoreUrl, dest, publisher, name, bar) => {
   let res = await axios.get(bitStoreUrl, {responseType: 'stream'}).catch(err => {
     if (err.response && err.response.status === 404) {
       if (dest.includes('README')) {
@@ -104,7 +104,7 @@ const downloadFile = async (bitStoreUrl, dest, publisher, pkg, bar) => {
   if(!res) {
     return
   }
-  let destPath = path.join(publisher,pkg,dest)
+  let destPath = path.join(publisher,name,dest)
   mkdirp.sync(path.dirname(destPath))
   res.data.pipe(fs.createWriteStream(destPath))
   bar.tick()

--- a/lib/info.js
+++ b/lib/info.js
@@ -6,9 +6,8 @@ const utils = require('../lib/utils/common')
 
 const getInfo = async (dhpkgid) => {
   spinner.start()
-  const { publisher, pkg } = utils.parseIdentifier(dhpkgid)
-
-  const metadata = await utils.getMetadata(publisher, pkg)
+  const { publisher, name } = utils.parseIdentifier(dhpkgid, 'datahub')
+  const metadata = await utils.getMetadata(publisher, name)
   let readme = await getReadme(urljoin(metadata.bitstore_url, 'README.md'))
   let firstParagraphReadme
 
@@ -32,7 +31,7 @@ const getInfo = async (dhpkgid) => {
   })
 
   spinner.stop()
-  
+
   // console.log first 200 chars of readme
   console.log('\n'+ customMarked(`***\n${firstParagraphReadme}\n***`))
 

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -3,14 +3,40 @@ const config = require('../config')
 const fs = require('fs')
 const urljoin = require('url-join')
 const {spinner} = require('./tools')
+const identifier = require('datapackage-identifier')
 
-const parseIdentifier = (dhpkgid) => {
-  const [publisher, pkg, path ] = dhpkgid.split('/')
-  return {
-    publisher,
-    pkg,
-    path
+const parseIdentifier = (dpId, type=null) => {
+  if(type === 'datahub') {
+    var dpIdArray = dpId.split('/')
+    // remove `/` in the beginning and in the end
+    dpId[0] === '/' ? dpIdArray.shift() : void(0)
+    dpId[dpId.length - 1] === '/' ? dpIdArray.pop() : void(0)
+    // get publisher, name and resourcePath
+    const [ publisher, name ] = dpIdArray
+    const resourcePath = dpIdArray.slice(2).join('/')
+    // for now assuming version is always 'latest'
+    const version = 'latest'
+    const path = urljoin(getBitStoreUrl(), 'metadata', publisher, name, '_v', version)
+    return {
+      publisher,
+      name,
+      resourcePath,
+      path,
+      dataPackageJsonPath: path + 'datapackage.json',
+      type,
+      original: dpId,
+      version
+    }
   }
+  return identifier.parse(dpId)
+}
+
+const getBitStoreUrl = (path=config.configDir) => {
+  const conf = config.readConfig(path)
+  if (conf) {
+    return conf.bitStore
+  }
+  return config.defaultBitStore
 }
 
 const getServerUrl = (path=config.configDir) => {
@@ -63,6 +89,7 @@ const getToken = async(config) => {
 }
 
 module.exports.getServerUrl = getServerUrl
+module.exports.getBitStoreUrl = getBitStoreUrl
 module.exports.checkDpIsThere = checkDpIsThere
 module.exports.parseIdentifier = parseIdentifier
 module.exports.getMetadata = getMetadata

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "crypto": "0.0.3",
     "csv-parse": "^1.2.0",
     "datapackage": "^1.0.0-alpha.4",
+    "datapackage-identifier": "^0.4.2",
     "expand-home-dir": "0.0.3",
     "form-data": "^2.1.4",
     "ini": "^1.3.4",

--- a/test/fixtures/config
+++ b/test/fixtures/config
@@ -1,3 +1,4 @@
 username=test
 accessToken=testToken
 server=https://test.com
+bitStore=https://bits-test.com

--- a/test/test_config.js
+++ b/test/test_config.js
@@ -7,7 +7,13 @@ test('reads from config file', t => {
   let exp = {
     username: 'test',
     accessToken: 'testToken',
-    server: 'https://test.com'
+    server: 'https://test.com',
+    bitStore: 'https://bits-test.com'
   }
   t.deepEqual(res, exp)
+})
+
+test('server and bitStore is set by default', t => {
+  t.is(config.defaultServer, 'https://staging.datapackaged.com')
+  t.is(config.defaultBitStore, 'https://bits-staging.datapackaged.com')
 })

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -30,7 +30,8 @@ let metadata = {
 let config = {
   username: 'test',
   secretToken: 'secret',
-  server: 'https://test.com'
+  server: 'https://test.com',
+  bitStore: 'https://bits-test.com'
 }
 
 test.beforeEach(t => {
@@ -103,15 +104,44 @@ test.serial('default log is working fine', t => {
 
 // common
 
-test('parseDataHubIdentifier parses correctly', t => {
-  let dhpkgid = 'publisher/package/resource'
-  let res = utils.parseIdentifier(dhpkgid)
+test('parseIdentifier parses given string correctly', t => {
+  let dpId = 'publisher/package/resource'
+  let res = utils.parseIdentifier(dpId, 'datahub')
   let exp = {
-    path: "resource",
-    pkg: "package",
+    name: "package",
     publisher: "publisher",
+    path: "https://bits-staging.datapackaged.com/metadata/publisher/package/_v/latest",
+    dataPackageJsonPath: "https://bits-staging.datapackaged.com/metadata/publisher/package/_v/latestdatapackage.json",
+    resourcePath: "resource",
+    type: "datahub",
+    original: "publisher/package/resource",
+    version: "latest"
   }
   t.deepEqual(res, exp)
+})
+
+test('parseIdentifier works with non-datahub type', t => {
+  let dpId = 'http://github.com/datasets/gdp'
+  let res = utils.parseIdentifier(dpId)
+  let exp = {
+    name: "gdp",
+    url: "http://raw.githubusercontent.com/datasets/gdp/master/",
+    dataPackageJsonUrl: "http://raw.githubusercontent.com/datasets/gdp/master/datapackage.json",
+    original: "http://github.com/datasets/gdp",
+    originalType: "",
+    version: "master"
+  }
+  t.deepEqual(res, exp)
+})
+
+test('Reads bitStore URL from config', t => {
+  let bitStoreUrl = utils.getBitStoreUrl('test/fixtures/config')
+  let exp = 'https://bits-test.com'
+  t.is(bitStoreUrl, exp)
+
+  bitStoreUrl = utils.getBitStoreUrl()
+  exp = 'https://bits-staging.datapackaged.com'
+  t.is(bitStoreUrl, exp)
 })
 
 test('Reads server URL from config', t => {


### PR DESCRIPTION
This PR includes:

* `parseIdentifier` function that parses identifier with given type `datahub`. If type is not specified it parses using `datapackage-identifier-js` library.
* new property in config - `bitStore` that is DataHub Bitstore url. It has a default value just like `server`.