### PR TITLE
Refactoring parseIdentifier to handle cwd

### DIFF
--- a/bin/data-info.js
+++ b/bin/data-info.js
@@ -27,7 +27,7 @@ const help = () => {
   console.log('\n'+ customMarked(infoMarkdown))
 }
 
-if (argv.help || !argv._[0]) {
+if (argv.help) {
   help()
   process.exit(0)
 }

--- a/lib/get.js
+++ b/lib/get.js
@@ -2,23 +2,28 @@ const axios = require('axios')
 const chalk = require('chalk')
 const Datapackage = require('datapackage').Datapackage
 const { elephant } = require('./utils/logo')
-const { bar } = require('./utils/tools')
+const { bar, spinner } = require('./utils/tools')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
 const path = require('path')
 const url = require('url')
 const urljoin = require('url-join')
 const utils = require('./utils/common')
+const { logger } = require('./utils/log-handler.js')
 
 module.exports.get = async(pkgid) => {
   let start = new Date()
   const idObj = utils.parseIdentifier(pkgid)
-  const dpObj = await new Datapackage(idObj.dataPackageJsonPath)
+  let dpObj
+  try {
+    dpObj = await new Datapackage(idObj.dataPackageJsonPath)
+  } catch(err) {
+    logger(err.message, 'error', true, spinner)
+  }
 
   const dist = checkDestIsEmpty(idObj.owner, idObj.name)
   if (!dist) {
-    console.error(`${idObj.owner}/${idObj.name} is not empty!`)
-    process.exit(1)
+    logger(`${idObj.owner}/${idObj.name} is not empty!`, 'error', true, spinner)
   }
 
   const filesToDownload = getFilesToDownload(idObj.path, dpObj.descriptor)
@@ -85,14 +90,12 @@ const downloadFile = async (path_, dest, owner, name, bar) => {
       if (dest.includes('README')) {
         return
       }
-      console.error('Data Not Found For ${dest}')
-      return
+      logger(`Data Not Found For ${dest}`, 'error', true, spinner)
     } else if (err.code === 'ECONNREFUSED') {
-      console.log(`Not able to connect to ${server}`)
-      return
+      logger(`Not able to connect to ${server}`, 'error', true, spinner)
     } else {
-      console.log('Failed to retrieve ${dest}')
-      console.error(err.message)
+      logger('Failed to retrieve ${dest}', 'error')
+      logger(err.message, 'error', true, spinner)
       return
     }
   })

--- a/lib/info.js
+++ b/lib/info.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const fs = require('fs')
 const urljoin = require('url-join')
 const Datapackage = require('datapackage').Datapackage
 const { customMarked, spinner } = require('./utils/tools.js')
@@ -8,8 +9,15 @@ const utils = require('../lib/utils/common')
 const getInfo = async (dhpkgid) => {
   spinner.start()
   const idObj = utils.parseIdentifier(dhpkgid)
-  const dpObj = await new Datapackage(idObj.dataPackageJsonPath)
-  let readme = await getReadme(urljoin(idObj.path, 'README.md'))
+  let dpObj, readme
+  if (idObj.dataPackageJsonPath.charAt(0) === '/') {
+    dpObj = await new Datapackage('datapackage.json')
+    readme = await getReadme(dpObj.descriptor)
+  } else {
+    dpObj = await new Datapackage(idObj.dataPackageJsonPath)
+    readme = await getReadme(dpObj.descriptor, urljoin(idObj.path, 'README.md'))
+  }
+
   let firstParagraphReadme
 
   if(readme) {
@@ -43,7 +51,20 @@ const getInfo = async (dhpkgid) => {
   console.log(customMarked(`# README\n${readme}\n***`))
 }
 
-const getReadme = async (url) => {
+const getReadme = async (descriptor, url) => {
+  // first check if readme is in descriptor
+  if(descriptor['readme']) {
+    return descriptor['readme']
+  }
+  // if url is not given then try to read from local disk
+  if(!url) {
+    try {
+      return fs.readFileSync('README.md').toString('utf8')
+    } catch(err) {
+      return void(0)
+    }
+  }
+  // if url is given then make a http call
   let res = await axios.get(url).catch(err => {
     return void(0)
   })

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -6,7 +6,7 @@ const {spinner} = require('./tools')
 const identifier = require('datapackage-identifier')
 
 const parseIdentifier = (dpId) => {
-  if(dpId && dpId.indexOf('http') === -1) {
+  if(dpId && dpId !== '.' && dpId.indexOf('http') === -1) {
     let dpIdArray = dpId.split('/')
     // remove `/` in the beginning and in the end
     dpId[0] === '/' ? dpIdArray.shift() : void(0)
@@ -30,7 +30,7 @@ const parseIdentifier = (dpId) => {
   } else { // if not datahub pkg id then use upstream library:
     let idObject
     // if dpId is not given then use cwd
-    if(!dpId) {
+    if(!dpId || dpId === '.') {
       dpId = './'
       idObject = identifier.parse(dpId)
       idObject['owner'] = null

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,9 +1,14 @@
 const Datapackage = require('datapackage').Datapackage
 const utils = require('./utils/common')
 
-const validate = async (pkgid='datapackage.json') => {
+const validate = async (pkgid) => {
   const idObj = utils.parseIdentifier(pkgid)
-  const dpObj = await new Datapackage(idObj.dataPackageJsonPath)
+  let dpObj
+  if (idObj.dataPackageJsonPath.charAt(0) === '/') {
+    dpObj = await new Datapackage('datapackage.json')
+  } else {
+    dpObj = await new Datapackage(idObj.dataPackageJsonPath)
+  }
   return dpObj.valid
 }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "commander": "^2.9.0",
     "crypto": "0.0.3",
     "csv-parse": "^1.2.0",
-    "datapackage": "^0.8.1",
+    "datapackage": "git+https://github.com/anuveyatsu/datapackage-js-temp.git",
     "datapackage-identifier": "^0.4.2",
     "expand-home-dir": "0.0.3",
     "form-data": "^2.1.4",

--- a/test/test_info.js
+++ b/test/test_info.js
@@ -62,17 +62,35 @@ test('gets descriptor and outputs list of resources', async t => {
   console.log.reset()
 })
 
+test('gets readme if readme exists in descriptor', async t => {
+  const descriptor = {
+    readme: 'some test readme'
+  }
+  const result = await info.getReadme(descriptor, undefined)
+
+  t.is(result, 'some test readme')
+})
+
+test('gets readme if data package is on disk', async t => {
+  const descriptor = {}
+  const result = await info.getReadme(descriptor, undefined)
+
+  t.true(result.includes('# Usage'))
+})
+
+test('gets readme if data package is remote', async t => {
+  const descriptor = {}
+  const readmeUrl = 'https://bits-staging.datapackaged.com/metadata/core/co2-ppm/_v/latest/README.md'
+  const result = await info.getReadme(descriptor, readmeUrl)
+
+  t.true(result.includes('CO2 PPM - Trends in Atmospheric Carbon Dioxide.'))
+})
+
 test('"data info [-help | -h]" prints out help message for info', async t => {
   console.log = t.context.log
 
-  let result = await data('info')
-  t.is(result.code, 0)
+  let result = await data('info', '-help')
   let stdout = result.stdout.split('\n')
-  t.true(stdout.length > 1)
-  t.true(stdout[1].includes('Preview a Data Package'))
-
-  result = await data('info', '-help')
-  stdout = result.stdout.split('\n')
   t.true(stdout.length > 1)
   t.true(stdout[1].includes('Preview a Data Package'))
 


### PR DESCRIPTION
* Refactored `info` and `validate` commands to handle cwd
* Refactored `info` command to handle inlined README + on disk
* Refactored `get` command to behave correctly when errors occur