### PR TITLE
data push file

### DIFF
--- a/bin/data-push.js
+++ b/bin/data-push.js
@@ -31,5 +31,6 @@ if (argv.help) {
   process.exit(0)
 }
 
+const filePath = argv._[0]
 
-push()
+push(filePath)

--- a/lib/init.js
+++ b/lib/init.js
@@ -185,14 +185,16 @@ const shouldWrite = async (descriptor) => {
 * @param {dpObj} instance of the datapackage
 * it wrties datapackage.json file to the disk
 */
-const writeDp = async (dpObj) => {
+const writeDp = async (dpObj, log=true) => {
   const cwd = path.join(process.cwd(), 'datapackage.json')
   const content = JSON.stringify(dpObj._descriptor, null, 2);
   fs.writeFile("./datapackage.json", content, 'utf8', function (err) {
-  if (err) {
-      return logger(err);
-  }
-  logger(`datapackage.json file is saved in ${cwd}`);
+    if (err) {
+        return logger(err)
+    }
+    if (log) {
+      logger(`datapackage.json file is saved in ${cwd}`)
+    }
   })
 }
 

--- a/lib/push.js
+++ b/lib/push.js
@@ -5,26 +5,45 @@ const fs = require('fs')
 const { logger } = require('./utils/log-handler')
 const { checkDpIsThere, getToken } = require('./utils/common')
 const { spinner } = require('./utils/tools')
+const { addResource, writeDp } = require('./init')
 const path = require('path')
 const request = require('request-promise-native')
 const urljoin = require('url-join')
+const Datapackage = require('datapackage').Datapackage
 
 
-const push = async() => {
-  spinner.start()
+const push = async(filePath) => {
+  let dpjson
+  // get configs
   const config = creds.readConfig()
   if (!config) {
     logger('Config file not found. Setup configurations by running "data config" command.', 'abort', true, spinner)
   }
-  if (!checkDpIsThere()) {
-    logger('datapckage.json not found!', 'abort', true, spinner)
+  // get dpjson
+  if(!filePath) {
+    if (!checkDpIsThere()) {
+      logger('datapckage.json not found!', 'abort', true, spinner)
+    }
+    dpjson = JSON.parse(fs.readFileSync('datapackage.json').toString())
+  } else {
+    // prepare temp descriptor for the single file push
+    let descriptor = {
+        name: filePath.replace(/^.*[\\\/]/, ''),
+        resources: []
+    }
+    const dpObj = await new Datapackage(descriptor)
+    await addResource(filePath, dpObj)
+    await writeDp(dpObj, false)
+    dpjson = dpObj._descriptor
   }
-  const dpjson = JSON.parse(fs.readFileSync('datapackage.json').toString())
+
+  // get token, get file info and signed urls
+  spinner.start()
   const token = await getToken(config)
   const files = getFileList(dpjson)
   const infoForRequest = getFilesForRequest(files, config.username, dpjson.name)
   const fileData = await getFileData(config, infoForRequest, token)
-
+  // upload
   let uploads = []
   files.forEach(file => {
     uploads.push(uploadFile(file, fileData[file]))
@@ -44,6 +63,10 @@ const push = async() => {
   const message = '🙌  your Data Package is published!\n'
   const url = '🔗  ' + urljoin(config.server, config.username, dpjson.name)
   logger(message + url, 'success', false, spinner)
+  // delete temporary created datapackage.json
+  if (filePath) {
+    fs.unlinkSync('datapackage.json')
+  }
 }
 
 const getFileData = async (config, fileInfo, token) => {

--- a/lib/push.js
+++ b/lib/push.js
@@ -32,7 +32,11 @@ const push = async(filePath) => {
         resources: []
     }
     const dpObj = await new Datapackage(descriptor)
-    await addResource(filePath, dpObj)
+    try {
+      await addResource(filePath, dpObj)
+    } catch (err) {
+      logger(err.message, `error`, true)
+    }
     await writeDp(dpObj, false)
     dpjson = dpObj._descriptor
   }

--- a/lib/push.js
+++ b/lib/push.js
@@ -13,6 +13,8 @@ const Datapackage = require('datapackage').Datapackage
 
 
 const push = async(filePath) => {
+  spinner.text = 'Preparing...'
+  spinner.start()
   let dpjson
   // get configs
   const config = creds.readConfig()
@@ -35,14 +37,13 @@ const push = async(filePath) => {
     try {
       await addResource(filePath, dpObj)
     } catch (err) {
-      logger(err.message, `error`, true)
+      logger(err.message, `error`, true, spinner)
     }
     await writeDp(dpObj, false)
     dpjson = dpObj._descriptor
   }
 
   // get token, get file info and signed urls
-  spinner.start()
   const token = await getToken(config)
   const files = getFileList(dpjson)
   const infoForRequest = getFilesForRequest(files, config.username, dpjson.name)

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const urljoin = require('url-join')
 const {spinner} = require('./tools')
 const identifier = require('datapackage-identifier')
+const { logger } = require('./log-handler')
 
 const parseIdentifier = (dpId) => {
   if(dpId && dpId !== '.' && dpId.indexOf('http') === -1) {
@@ -76,8 +77,8 @@ const getServerUrl = (path=config.configDir) => {
   return config.defaultServer
 }
 
-const checkDpIsThere = () => {
-  const files = fs.readdirSync(process.cwd())
+const checkDpIsThere = (path_=process.cwd()) => {
+  const files = fs.readdirSync(path_)
   return files.indexOf('datapackage.json') > -1
 }
 

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -192,6 +192,11 @@ test('Checks if datapackage.json exists in cwd', t => {
   t.false(out)
 })
 
+test('Checks if datapackage.json exists in given dir', t => {
+  let out = utils.checkDpIsThere('test/fixtures')
+  t.true(out)
+})
+
 test('Gets bitStoreUrl if publisher and package is fine', async t => {
   let sUrl = utils.getServerUrl('not/config')
   let res = utils.getMetadata('publisher', 'package', sUrl)


### PR DESCRIPTION
Implemented `$ data push {file}` command:

* refactored old `push` command so when there is an argument given it assumes it is a file path
* builds minimal dp object
* adds given file as a resource
* temporarily writes `datapackage.json` file for uploading process
* deletes it after upload

In addition:

* refactored `checkDpIsThere` function to handle not only cwd but also any given dir