### PR TITLE
Function for parsing paths

### DIFF
--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -118,9 +118,15 @@ const getToken = async(config) => {
   return res.data.token
 }
 
+const isUrl = path_ => {
+  let r = new RegExp('^(?:[a-z]+:)?//', 'i')
+  return r.test(path_)
+}
+
 module.exports.getServerUrl = getServerUrl
 module.exports.getBitStoreUrl = getBitStoreUrl
 module.exports.checkDpIsThere = checkDpIsThere
 module.exports.parseIdentifier = parseIdentifier
 module.exports.getMetadata = getMetadata
 module.exports.getToken = getToken
+module.exports.isUrl = isUrl

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -1,6 +1,9 @@
 const axios = require('axios')
 const config = require('../config')
 const fs = require('fs')
+const path = require('path')
+const mime = require('mime-types')
+const chardet = require('chardet')
 const urljoin = require('url-join')
 const {spinner} = require('./tools')
 const identifier = require('datapackage-identifier')
@@ -59,6 +62,27 @@ const parseIdentifier = (dpId) => {
     delete idObject['originalType']
     return idObject
   }
+}
+
+const parsePath = (path_) => {
+  const dataResource = {path: path_}
+        , isItUrl = isUrl(path_)
+        , fileName = path_.replace(/^.*[\\\/]/, '')
+        , extension = path.extname(fileName)
+        , resourceName = fileName.replace(extension, "")
+        , format = extension.slice(1)
+        , mimeType = mime.lookup(path_) || ''
+  dataResource.pathType = isItUrl ? 'remote' : 'local'
+  dataResource.name = resourceName
+  dataResource.format = format
+  dataResource.mediatype = mimeType
+  if (!isItUrl) {
+    const encoding = chardet.detectFileSync(path_)
+    dataResource.encoding = encoding
+  } else {
+    dataResource.encoding = null
+  }
+  return dataResource
 }
 
 const getBitStoreUrl = (path=config.configDir) => {
@@ -127,6 +151,7 @@ module.exports.getServerUrl = getServerUrl
 module.exports.getBitStoreUrl = getBitStoreUrl
 module.exports.checkDpIsThere = checkDpIsThere
 module.exports.parseIdentifier = parseIdentifier
+module.exports.parsePath = parsePath
 module.exports.getMetadata = getMetadata
 module.exports.getToken = getToken
 module.exports.isUrl = isUrl

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "axios": "^0.16.1",
     "chalk": "^1.1.3",
+    "chardet": "^0.1.0",
     "commander": "^2.9.0",
     "crypto": "0.0.3",
     "csv-parse": "^1.2.0",
@@ -62,6 +63,7 @@
     "inquirer": "^3.1.1",
     "marked": "^0.3.6",
     "marked-terminal": "^2.0.0",
+    "mime-types": "^2.1.15",
     "minimist": "^1.2.0",
     "opn": "^5.1.0",
     "ora": "^1.2.0",

--- a/test/test_config.js
+++ b/test/test_config.js
@@ -13,7 +13,8 @@ test.serial('runs config command with data input', async t => {
   const result = await(run(cliPath, [
     'my-username', ENTER
   ]))
-  t.true(result.includes('? Username:  my-username'))
+  t.true(result.includes('? Username:'))
+  t.true(result.includes('my-username'))
 })
 
 test('reads from config file', t => {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -229,3 +229,25 @@ test('Tests if given path is url or not', t => {
   res = utils.isUrl(url)
   t.true(res)
 })
+
+test('parsePath function with local path', t => {
+  const path_ = 'test/fixtures/sample.csv'
+  const res = utils.parsePath(path_)
+  t.is(res.path, path_)
+  t.is(res.pathType, 'local')
+  t.is(res.name, 'sample')
+  t.is(res.format, 'csv')
+  t.is(res.mediatype, 'text/csv')
+  t.is(res.encoding, 'ISO-8859-1')
+})
+
+test('parsePath function with remote url', t => {
+  const path_ = 'https://raw.githubusercontent.com/datasets/finance-vix/master/data/vix-daily.csv'
+  const res = utils.parsePath(path_)
+  t.is(res.path, path_)
+  t.is(res.pathType, 'remote')
+  t.is(res.name, 'vix-daily')
+  t.is(res.format, 'csv')
+  t.is(res.mediatype, 'text/csv')
+  t.is(res.encoding, null)
+})

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -208,3 +208,24 @@ test.serial('Gets the token', async t => {
   const expToken = 't35tt0k3N'
   t.is(token, expToken)
 })
+
+test('Tests if given path is url or not', t => {
+  let notUrl = 'not/url/path'
+  let res = utils.isUrl(notUrl)
+  t.false(res)
+  notUrl = '/not/url/path/'
+  res = utils.isUrl(notUrl)
+  t.false(res)
+  let url = 'https://test.com'
+  res = utils.isUrl(url)
+  t.true(res)
+  url = 'http://test.com'
+  res = utils.isUrl(url)
+  t.true(res)
+  url = 'HTTP://TEST.COM'
+  res = utils.isUrl(url)
+  t.true(res)
+  url = '//test.com'
+  res = utils.isUrl(url)
+  t.true(res)
+})


### PR DESCRIPTION
`parsePath` function:
* gets string that is either local path to a resource or remote url
* returns dict in following form:
```json=
{
  path: myfile.csv
  pathType: local | remote
  name: myfile
  format: (file extension if determinable)
  mediaType: text/csv
  encoding: 'utf-8'
}
```