### PR TITLE
method to handle pushing remote datasets'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: node_js
 
 node_js:
   - "8"
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-4.9-dev
 
 install:
   - npm install

--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -6,6 +6,9 @@ const {File, xlsxParser} = require('data.js')
 const XLSX = require('xlsx')
 const toArray = require('stream-to-array')
 const infer = require('tableschema').infer
+const Git = require('nodegit')
+const tmp = require('tmp')
+const YAML = require('yamljs')
 
 const {Agent} = require('./agent')
 
@@ -95,7 +98,40 @@ class DataHub extends EventEmitter {
     this._debugMsg('Calling source upload with spec')
     this._debugMsg(spec)
 
+
     const token = await this._authz('source')
+    const res = await this._fetch('/source/upload', token, {
+      method: 'POST',
+      body: spec
+    })
+
+    if (res.status === 200) {
+      const out = await res.json()
+      this._debugMsg(out)
+      return out
+    }
+    throw new Error(responseError(res))
+  }
+
+  async pushFlow(url){
+    const tmpdir = tmp.dirSync()
+    try {
+      await Git.Clone(url, tmpdir.name)
+    } catch (err) {
+      throw new Error(`Failed to clone from ${url}`)
+    }
+    let spec = {}
+    try {
+      spec = YAML.load(`${tmpdir.name}/.datahub/flow.yaml`)
+    } catch (err) {
+      throw new Error(`.datahub/flow.yaml Does not exist`)
+    }
+
+    this._debugMsg('Calling source upload with spec')
+    this._debugMsg(spec)
+
+    const token = await this._authz('source')
+    this._debugMsg(token)
     const res = await this._fetch('/source/upload', token, {
       method: 'POST',
       body: spec

--- a/package.json
+++ b/package.json
@@ -83,13 +83,16 @@
     "mkdirp": "^0.5.1",
     "nconf": "^0.8.4",
     "node-fetch": "^1.7.1",
+    "nodegit": "^0.20.2",
     "opn": "^5.1.0",
     "ora": "^1.2.0",
     "progress": "^2.0.0",
     "tableschema": "1.0.0-alpha.14",
+    "tmp": "0.0.33",
     "tv4": "^1.3.0",
     "url-join": "^2.0.2",
-    "xlsx": "^0.10.8"
+    "xlsx": "^0.10.8",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",


### PR DESCRIPTION
* this function is not usedby CLI yet.
* It may be used by requiring datahub.js and passing git url to `datahub.pushFlow`
* function awaits that source specifications are defined in .datahub/flow.yaml of git repo
* not includes tests as there's no easy way to mock `nodegit` library