### PR TITLE
Method to handle pushing remote datasets

### DIFF
--- a/bin/data-push-flow.js
+++ b/bin/data-push-flow.js
@@ -50,8 +50,8 @@ Promise.resolve().then(async () => {
     process.exit(0)
   }
   try {
-    const filePath = argv._[0] || process.cwd()
-    dataset = await Dataset.load(filePath)
+    const datasetPath = argv._[0] || process.cwd()
+    dataset = await Dataset.load(datasetPath)
     stopSpinner = wait('Commencing push ...')
 
     const datahub = new DataHub({
@@ -61,7 +61,7 @@ Promise.resolve().then(async () => {
       ownerid: config.get('profile').id,
       owner: config.get('profile').username
     })
-    await datahub.pushFlow(path.join(__dirname, filePath ,'.datahub/flow.yaml')
+    await datahub.pushFlow(path.join(__dirname, datasetPath ,'.datahub/flow.yaml')
 
     stopSpinner()
     const message = '🙌  your data is published!\n'

--- a/bin/data-push-flow.js
+++ b/bin/data-push-flow.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const minimist = require('minimist')
+const urljoin = require('url-join')
+const {Dataset} = require('data.js')
+const { write: copyToClipboard } = require('clipboardy')
+
+// Ours
+const config = require('../lib/utils/config')
+const {customMarked} = require('../lib/utils/tools.js')
+const {handleError} = require('../lib/utils/error')
+const wait = require('../lib/utils/output/wait')
+const {DataHub} = require('../lib/utils/datahub.js')
+const {authenticate} = require('../lib/login')
+const info = require('../lib/utils/output/info.js')
+
+
+const argv = minimist(process.argv.slice(2), {
+  string: ['push-flow'],
+  boolean: ['help', 'debug', 'interactive'],
+  alias: {help: 'h', interactive: 'i'}
+})
+
+const pushMarkdown = fs.reSync(path.join(__dirname, '../docs/push-flow.md'), 'utf8')
+const help = () => {
+  console.log('\n' + customMarked(pushMarkdown))
+}
+
+if (argv.help) {
+  help()
+  process.exit(0)
+}
+
+Promise.resolve().then(async () => {
+  let stopSpinner = () => {}
+  // First check if user is authenticated
+  const apiUrl = config.get('api')
+  const token = config.get('token')
+  let out
+  try {
+    out = await authenticate(apiUrl, token)
+  } catch (err) {
+    handleError(err)
+    process.exit(1)
+  }
+  if (!out.authenticated) {
+    info('You need to login in order to push your data. Please, use `data login` command.')
+    process.exit(0)
+  }
+  try {
+    const filePath = argv._[0] || process.cwd()
+    dataset = await Dataset.load(filePath)
+    stopSpinner = wait('Commencing push ...')
+
+    const datahub = new DataHub({
+      apiUrl: config.get('api'),
+      token: config.get('token'),
+      debug: argv.debug,
+      ownerid: config.get('profile').id,
+      owner: config.get('profile').username
+    })
+    await datahub.pushFlow(path.join(__dirname, filePath ,'.datahub/flow.yaml')
+
+    stopSpinner()
+    const message = '🙌  your data is published!\n'
+    const url = urljoin(config.get('domain'), config.get('profile').username, dataset.descriptor.name)
+    await copyToClipboard(url)
+    console.log(message + '🔗  ' + url + ' (copied to clipboard)')
+  } catch (err) {
+    stopSpinner()
+    handleError(err)
+    if (argv.debug) {
+      console.log('> [debug]\n' + err.stack)
+    }
+    process.exit(1)
+  }
+})

--- a/bin/data.js
+++ b/bin/data.js
@@ -26,6 +26,7 @@ const commands = new Set([
   'help',
   'get',
   'push',
+  'push-flow',
   'normalize',
   'norm',
   'validate',

--- a/docs/push-flow.md
+++ b/docs/push-flow.md
@@ -1,0 +1,21 @@
+■ data push-flow [PATH]
+
+  `PATH` (optional) is the path to the data package.
+
+Options:
+
+  -h, --help               Output usage information
+
+**Examples**
+
+\- Uploads Data Package to DataHub in current working directory
+
+  ■ data push-flow
+
+  data package should have ./datahub/flow.yaml
+
+\- Uploads Data Package to DataHub with path:
+
+  ■ data push-flow core/finance-vix/
+
+  core/finance-vix/ should have datapackage.json and ./datahub/flow.yaml

--- a/docs/push-flow.md
+++ b/docs/push-flow.md
@@ -12,10 +12,10 @@ Options:
 
   ■ data push-flow
 
-  data package should have ./datahub/flow.yaml
+  data package should have .datahub/flow.yaml
 
 \- Uploads Data Package to DataHub with path:
 
   ■ data push-flow core/finance-vix/
 
-  core/finance-vix/ should have datapackage.json and ./datahub/flow.yaml
+  core/finance-vix/ should have datapackage.json and .datahub/flow.yaml

--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -6,6 +6,7 @@ const {File, xlsxParser} = require('data.js')
 const XLSX = require('xlsx')
 const toArray = require('stream-to-array')
 const infer = require('tableschema').infer
+const YAML = require('yamljs')
 
 const {Agent} = require('./agent')
 
@@ -91,6 +92,32 @@ class DataHub extends EventEmitter {
 
     // Upload to SpecStore
     const spec = await makeSourceSpec(rawstoreUploadCreds, this._ownerid, this._owner, dataset, options)
+
+    this._debugMsg('Calling source upload with spec')
+    this._debugMsg(spec)
+
+
+    const token = await this._authz('source')
+    const res = await this._fetch('/source/upload', token, {
+      method: 'POST',
+      body: spec
+    })
+
+    if (res.status === 200) {
+      const out = await res.json()
+      this._debugMsg(out)
+      return out
+    }
+    throw new Error(responseError(res))
+  }
+
+  async pushFlow(specPath){
+    let spec = {}
+    try {
+      spec = YAML.load(specPath)
+    } catch (err) {
+      throw new Error(err.message)
+    }
 
     this._debugMsg('Calling source upload with spec')
     this._debugMsg(spec)

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "tableschema": "1.0.0-alpha.14",
     "tv4": "^1.3.0",
     "url-join": "^2.0.2",
-    "xlsx": "^0.10.8"
+    "xlsx": "^0.10.8",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",

--- a/test/fixtures/finance-vix/.datahub/flow.yaml
+++ b/test/fixtures/finance-vix/.datahub/flow.yaml
@@ -1,0 +1,26 @@
+meta:
+  dataset: finance-vix
+  findability: published
+  owner: test
+  ownerid: testid
+  version: 1
+inputs:
+- kind: datapackage
+  parameters:
+    resource-mapping:
+      vix-daily: http:/testing.com/vixcurrent.csv
+  url: http:/testing.com/.datahub/datapackage.json
+processing:
+  -
+    input: vix-daily
+    tabulator:
+      skip_rows: 2
+      headers:
+        - Date
+        - VIXOpen
+        - VIXHigh
+        - VIXLow
+        - VIXClose
+    output: vix-daily
+schedule:
+    crontab: '0 0 * * *'


### PR DESCRIPTION
* `push-flow` has much alike functionality like `data push`, just much simpler
  * no communication with rawstore  (for now) as this is for remote resources
  * No source-spec generation, as it awaits to be defined in `.datahub/flow.yaml`
* simple CLI support (also much alike `data push`)
* tests
* help
Refs #184