### PR TITLE
[normalize][s]: sources and resources properties normalized - refs #186

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -54,22 +54,17 @@ const normalizeNames = dp => {
   return dp
 }
 
-const normalizeLicenseName = dp => {
-  for (const idx in dp.licenses) {
-    if (dp.licenses[idx].name) {
-      dp.licenses[idx].name = dp.licenses[idx].name.toLowerCase().replace(/\s/g, '_')
-    }
-  }
-  return dp
-}
 
 const normalizeLicenses = dp => {
   if (dp.license) {
-    dp.licenses = dp.license
-    delete dp.license
-    normalizeLicenseName(dp)
-  } else {
-    normalizeLicenseName(dp)
+    if (typeof dp.license === 'string' || dp.license instanceof String) {
+      dp.licenses = new Array()
+      dp.licenses.push({name: dp.license})
+      delete dp.license
+    }  else {
+      dp.licenses = dp.license
+      delete dp.license
+    }
   }
   return dp
 }
@@ -184,6 +179,6 @@ module.exports.normalizeAll = normalizeAll
 module.exports.nomralizeDateFormat = nomralizeDateFormat
 module.exports.normalizeNames = normalizeNames
 module.exports.normalizeSchema = normalizeSchema
-module.exports.normalizeLicenseName = normalizeLicenseName
+module.exports.normalizeLicenses = normalizeLicenses
 module.exports.normalizeSources = normalizeSources
 module.exports.normalizeType = normalizeType

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -63,20 +63,31 @@ const normalizeLicenseName = dp => {
   return dp
 }
 
+const normalizeLicenses = dp => {
+  if (dp.license) {
+    dp.licenses = dp.license
+    delete dp.license
+    normalizeLicenseName(dp)
+  } else {
+    normalizeLicenseName(dp)
+  }
+  return dp
+}
+
 const normalizeSources = dp => {
   for (const idx in dp.sources) {
-    dp.sources[idx].title = dp.sources[idx].name
+    if (!dp.sources[idx].title) {
+      dp.sources[idx].title = dp.sources[idx].name ? dp.sources[idx].name:'unknown'
+    }
+    if (dp.sources[idx].web && !dp.sources[idx].path) {
+      dp.sources[idx].path = dp.sources[idx].web
+      delete dp.sources[idx].web
+    }
   }
   for (const idx in dp.resources) {
     for (const id in dp.resources[idx].sources) {
-      if (dp.resources[idx].sources[id].title) {
-        dp.resources[idx].sources[id].title = dp.resources[idx].sources[id].title
-      }
-      else if (dp.resources[idx].sources[id].name) {
-        dp.resources[idx].sources[id].title = dp.resources[idx].sources[id].name
-      }
-      else {
-        dp.resources[idx].sources[id].title = 'unknown'
+      if (!dp.resources[idx].sources[id].title) {
+        dp.resources[idx].sources[id].title = dp.resources[idx].sources[id].name ? dp.resources[idx].sources[id].name: 'unknown'
       }
     }
   }
@@ -97,7 +108,7 @@ const normalizeContributors = dp => {
       delete dp.author
       normalizeContributorsTitle(dp)
     } else {
-      dp.contributors = new Array();
+      dp.contributors = new Array()
       dp.contributors.push({title: dp.author})
       delete dp.author
       normalizeContributorsTitle(dp)
@@ -114,8 +125,7 @@ const normalizePath = dp => {
       if (dp.resources[idx].url) {
         delete dp.resources[idx].url
       }
-    }
-    else if (dp.resources[idx].url) {
+    } else if (dp.resources[idx].url) {
       dp.resources[idx].path = dp.resources[idx].url
       delete dp.resources[idx].url
     }
@@ -129,7 +139,7 @@ const normalizeAll = dp => {
   dp = nomralizeDateFormat(dp)
   dp = normalizeType(dp)
   dp = normalizeNames(dp)
-  dp = normalizeLicenseName(dp)
+  dp = normalizeLicenses(dp)
   dp = normalizeSources(dp)
   dp = normalizeContributors(dp)
   return dp

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const {join, parse} = require('path')
+const lodash = require('lodash')
 
 const normalizeSchema = dp => {
   for (const propertyName in dp) {
@@ -56,12 +57,12 @@ const normalizeNames = dp => {
 
 
 const normalizeLicenses = dp => {
-  if (dp.license) {
-    if (typeof dp.license === 'string' || dp.license instanceof String) {
+  if (dp.license) { // Rename to licenses and normalize
+    if (lodash.isString(dp.license)) {
       dp.licenses = new Array()
       dp.licenses.push({name: dp.license})
       delete dp.license
-    }  else {
+    } else if (lodash.isArray(dp.license)) {
       dp.licenses = dp.license
       delete dp.license
     }

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -53,10 +53,6 @@ const dp = {
   ]
 }
 
-const dpLicense = {
-  license: 'PDDL-1.0'
-}
-
 test('checks normalized all properties', t => {
   const res = normalizeAll(dp)
   const exp = {
@@ -115,12 +111,19 @@ test('checks normalized all properties', t => {
   t.deepEqual(res, exp)
 })
 
-test('checks normalized license when it is type of string', t => {
-  const res = normalizeLicenses(dpLicense)
+test('normalizeLicenses function', t => {
+  let dp = {
+    license: 'PDDL-1.0'
+  }
+  let res = normalizeLicenses(dp)
   const exp = {
     licenses: [{
       name: 'PDDL-1.0'
     }]
+  }
+  t.deepEqual(res, exp)
+  dp = {
+    license: {name: 'PDDL-1.0'}
   }
   t.deepEqual(res, exp)
 })

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const {
-  normalizeAll
+  normalizeAll, normalizeLicenses
 } = require('../lib/normalize.js')
 const {runcli} = require('./cli.test.js')
 
@@ -8,7 +8,7 @@ const dp = {
   name: 'example',
   author: 'Mikane',
   license: {
-    name: 'example license',
+    name: 'example_license',
     url: 'https://example/license.com'
   },
   resources: [
@@ -51,6 +51,10 @@ const dp = {
       email: 'test@gmail.com'
     }
   ]
+}
+
+const dpLicense = {
+  license: 'PDDL-1.0'
 }
 
 test('checks normalized all properties', t => {
@@ -107,6 +111,16 @@ test('checks normalized all properties', t => {
         title: 'Mikane'
       }
     ]
+  }
+  t.deepEqual(res, exp)
+})
+
+test('checks normalized license when it is type of string', t => {
+  const res = normalizeLicenses(dpLicense)
+  const exp = {
+    licenses: [{
+      name: 'PDDL-1.0'
+    }]
   }
   t.deepEqual(res, exp)
 })

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -1,13 +1,13 @@
 const test = require('ava')
 const {
-  normalizeSchema, normalizeType, nomralizeDateFormat, normalizeAll, normalizeNames
+  normalizeAll
 } = require('../lib/normalize.js')
 const {runcli} = require('./cli.test.js')
 
 const dp = {
   name: 'example',
   author: 'Mikane',
-  licenses: {
+  license: {
     name: 'example license',
     url: 'https://example/license.com'
   },
@@ -39,7 +39,8 @@ const dp = {
   ],
   sources: [
     {
-      name: 'source-name'
+      name: 'source-name',
+      web: 'https://example/source.com'
     }
   ],
   contributors: [
@@ -89,7 +90,8 @@ test('checks normalized all properties', t => {
     sources: [
       {
         title: 'source-name',
-        name: 'source-name'
+        name: 'source-name',
+        path: 'https://example/source.com'
       }
     ],
     contributors: [
@@ -99,12 +101,11 @@ test('checks normalized all properties', t => {
       },
       {
         email: 'test@gmail.com',
-        title: ''      
+        title: ''
       },
       {
         title: 'Mikane'
-      },
-    
+      }
     ]
   }
   t.deepEqual(res, exp)


### PR DESCRIPTION
* merge `normalizeLicenseName` function into `normalizeLicenses` into
  * `license` is `licenses` and it is array of objects
* refactor `normalizeSources` function to merge `sources.web`  into `sources.path`
* removed `normalizeLicensesNames` function which normalizes `name` property.
  * The reason: According to the spec v1  https://specs.frictionlessdata.io/data-package/#licenses, the `name` property can be in any format