### PR TITLE
Requesting signed urls before attaching to source spec

### DIFF
--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -88,7 +88,7 @@ class DataHub extends EventEmitter {
     this._debugMsg('Uploading to source spec store')
 
     // Upload to SpecStore
-    const spec = await makeSourceSpec(rawstoreUploadCreds, this._ownerid, this._owner, dataset, options)
+    const spec = await this.makeSourceSpec(rawstoreUploadCreds, dataset, options)
 
     this._debugMsg('Calling source upload with spec')
     this._debugMsg(spec)
@@ -203,43 +203,62 @@ class DataHub extends EventEmitter {
       console.log('> [debug] ' + msg)
     }
   }
-}
 
-const makeSourceSpec = async (rawstoreResponse, ownerid, owner, dataset, options) => {
-  const resourceMapping = {}
-  lodash.forEach(rawstoreResponse, (uploadInfo, resourceName) => {
-    if (resourceName !== 'datapackage.json') {
-      resourceMapping[resourceName] = uploadInfo.rawstore_url
-    }
-  })
-  let processing = await processExcelSheets(dataset.resources, options.sheets)
-  processing = processing[0] ? processing : undefined
-  let outputs = handleOutputs(options.outputs)
-  outputs = outputs[0] ? outputs : undefined
-  const schedule = options.schedule
-  return {
-    meta: {
-      version: 1,
-      ownerid,
-      owner,
-      dataset: dataset.descriptor.name,
-      findability: options.findability
-    },
-    inputs: [
-      {
-        kind: 'datapackage',
-        // Above we set the "name" for the data package resource to be
-        // datapackage.json so we use that name to look it up in rawstoreResponse
-        url: rawstoreResponse['datapackage.json'].rawstore_url,
-        parameters: {
-          'resource-mapping': resourceMapping,
-          'descriptor': dataset.descriptor
+
+  async makeSourceSpec(rawstoreResponse, dataset, options) {
+    const resourceMapping = {}
+    const token = await this._authz('rawstore')
+    lodash.forEach(rawstoreResponse, async (uploadInfo, resourceName) => {
+      if (resourceName !== 'datapackage.json') {
+        const res = await this._fetch(
+            `/rawstore/presign?ownerid=${this._ownerid}&url=${uploadInfo.rawstore_url}`,
+            token, {method: 'GET'}
+        )
+        if (res.status !== 200) {
+          throw new Error(responseError(res))
         }
+        const signedurl = await res.json()
+        resourceMapping[resourceName] = signedurl.url
       }
-    ],
-    outputs,
-    processing,
-    schedule
+    })
+    let processing = await processExcelSheets(dataset.resources, options.sheets)
+    processing = processing[0] ? processing : undefined
+    let outputs = handleOutputs(options.outputs)
+    outputs = outputs[0] ? outputs : undefined
+    const schedule = options.schedule
+    const dpUrl = rawstoreResponse['datapackage.json'].rawstore_url
+    const res = await this._fetch(
+        `/rawstore/presign?ownerid=${this._ownerid}&url=${dpUrl}`,
+        token, {method: 'GET'}
+    )
+    if (res.status !== 200) {
+      throw new Error(responseError(res))
+    }
+    const dpSignedurl = await res.json()
+    return {
+      meta: {
+        version: 1,
+        ownerid: this._ownerid,
+        owner: this._owner,
+        dataset: dataset.descriptor.name,
+        findability: options.findability
+      },
+      inputs: [
+        {
+          kind: 'datapackage',
+          // Above we set the "name" for the data package resource to be
+          // datapackage.json so we use that name to look it up in rawstoreResponse
+          url: dpSignedurl.url,
+          parameters: {
+            'resource-mapping': resourceMapping,
+            'descriptor': dataset.descriptor
+          }
+        }
+      ],
+      outputs,
+      processing,
+      schedule
+    }
   }
 }
 
@@ -325,6 +344,5 @@ async function responseError(res) {
 module.exports = {
   DataHub,
   processExcelSheets,
-  handleOutputs,
-  makeSourceSpec
+  handleOutputs
 }


### PR DESCRIPTION
This PR allows CLI to check URLs received from `/rawstore/authorize` for the need of signed URLs. Meaning After putting files on `rawstore` Instead of directly grabbing rile URL from  response CLI will first hit `rawstore/presign` endpoint with token, userid and URL and attaches to source spec URL returned via API. 

refs #202 

PR includes mocks for request and slight change in generating function that generates source spec (makes requests)


**Note:** Work for `rawstore/presign` is still in progress (due to security problems), So do **not** merge until this PR is merged https://github.com/datahq/bitstore/pull/19 (or at least do not include in new release)