### PR TITLE
Update notifications

### DIFF
--- a/bin/data.js
+++ b/bin/data.js
@@ -7,6 +7,7 @@ const {version} = require('../package.json')
 // Ours
 const {error} = require('../lib/utils/error')
 const {handleError} = require('../lib/utils/error')
+const updateNotifier = require('../lib/utils/update')
 
 // Handle all uncaught exceptions and unhandled rejections
 process.on('uncaughtException', (err) => {
@@ -16,6 +17,9 @@ process.on('uncaughtException', (err) => {
 process.on('unhandledRejection', (err) => {
   handleError(err)
 })
+
+// Check and notify if any updates are available:
+updateNotifier()
 
 // Check if the current path exists and throw and error
 // if the user is trying to deploy a non-existing path!

--- a/lib/utils/update.js
+++ b/lib/utils/update.js
@@ -13,30 +13,31 @@ module.exports = () => {
   }
 
   // Depending on running OS show appropriate instructions:
-  let instructions = 'If you\'ve installed data tool using our executable binary then follow instructions below:\n'
-  if (process.platform === 'darwin') {
-    // Instructions for macos:
-    instructions += `\n$ curl -L https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-macos.gz -o ./data.gz`
-    instructions += '\n$ gunzip -f data.gz && chmod +x data && sudo mv data /usr/local/bin/data'
-  } else if (process.platform === 'linux') {
-    // Instructions for linux:
-    instructions += `\n$ wget https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-linux.gz`
-    instructions += '\n$ gunzip -f data-linux.gz && chmod +x data-linux && sudo mv data-linux /usr/local/bin/data'
-  } else if (process.platform === 'win32') {
-    // Instructions for windows:
-    instructions += '\nDepending on your Windows distribution and configurations, you may need to use different path when moving the executable.\n'
-    instructions += '\nYou need to run `move` command as administrator:'
-    instructions += `\n$ curl -k --insecure -L https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-win.exe.gz -o ./data.gz`
-    instructions += '\n$ gzip -d data.gz && move data "C:\\Windows\\System32\\data.exe"'
+  const introduction = 'If you\'ve installed data tool using our executable binary then follow instructions below:\n'
+  const instructions = {
+    'darwin': `\ncurl -L https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-macos.gz -o ./data.gz
+gunzip -f data.gz && chmod +x data && sudo mv data /usr/local/bin/data`,
+    'linux': `\nwget https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-linux.gz
+gunzip -f data-linux.gz && chmod +x data-linux && sudo mv data-linux /usr/local/bin/data`,
+    'win32': `\nDepending on your Windows distribution and configurations, you may need to use different path when moving the executable.\n
+You need to run 'move' command as administrator:
+curl -k --insecure -L https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-win.exe.gz -o ./data.gz
+gzip -d data.gz && move data "C:\\Windows\\System32\\data.exe"`
   }
-  instructions += `\n$ data -v # should print ${notifier.update.latest}`
+  const summary = `\ndata -v # should print ${notifier.update.latest}`
 
   if (notifier.update) {
     notifier.notify({
       defer: false,
       isGlobal: true
     })
-    console.log(boxen(instructions, {padding: 1, margin: 1, align: 'left', borderColor: 'yellow', borderStyle: 'round'}))
+    console.log(boxen(introduction + instructions[process.platform] + summary, {
+      padding: 1,
+      margin: 1,
+      align: 'left',
+      borderColor: 'yellow',
+      borderStyle: 'round'
+    }))
   } else {
     return
   }

--- a/lib/utils/update.js
+++ b/lib/utils/update.js
@@ -1,0 +1,43 @@
+const pkg = require('../../package.json')
+const updateNotifier = require('update-notifier')
+const boxen = require('boxen')
+
+module.exports = () => {
+  const notifier = updateNotifier({
+    pkg,
+    updateCheckInterval: 1000 * 60 * 60
+  })
+
+  if (!notifier.update) {
+    return
+  }
+
+  // Depending on running OS show appropriate instructions:
+  let instructions = 'If you\'ve installed data tool using our executable binary then follow instructions below:\n'
+  if (process.platform === 'darwin') {
+    // Instructions for macos:
+    instructions += `\n$ curl -L https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-macos.gz -o ./data.gz`
+    instructions += '\n$ gunzip -f data.gz && chmod +x data && sudo mv data /usr/local/bin/data'
+  } else if (process.platform === 'linux') {
+    // Instructions for linux:
+    instructions += `\n$ wget https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-linux.gz`
+    instructions += '\n$ gunzip -f data-linux.gz && chmod +x data-linux && sudo mv data-linux /usr/local/bin/data'
+  } else if (process.platform === 'win32') {
+    // Instructions for windows:
+    instructions += '\nDepending on your Windows distribution and configurations, you may need to use different path when moving the executable.\n'
+    instructions += '\nYou need to run `move` command as administrator:'
+    instructions += `\n$ curl -k --insecure -L https://github.com/datahq/data-cli/releases/download/v${notifier.update.latest}/data-win.exe.gz -o ./data.gz`
+    instructions += '\n$ gzip -d data.gz && move data "C:\\Windows\\System32\\data.exe"'
+  }
+  instructions += `\n$ data -v # should print ${notifier.update.latest}`
+
+  if (notifier.update) {
+    notifier.notify({
+      defer: false,
+      isGlobal: true
+    })
+    console.log(boxen(instructions, {padding: 1, margin: 1, align: 'left', borderColor: 'yellow', borderStyle: 'round'}))
+  } else {
+    return
+  }
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "homepage": "https://datahub.io/docs",
   "dependencies": {
     "ansi-escapes": "^3.0.0",
+    "boxen": "^1.3.0",
     "chalk": "^2.3.0",
     "clipboardy": "^1.1.4",
     "data.js": "^0.10.0",
@@ -82,6 +83,7 @@
     "mkdirp": "^0.5.1",
     "ora": "^1.3.0",
     "pkg": "4.2.5",
+    "update-notifier": "^2.3.0",
     "url-join": "^2.0.2",
     "xlsx": "^0.10.8"
   },


### PR DESCRIPTION
Implemented module for notifying users about new versions of the cli tool:

- 'lib/utils/update.js' is the module which is responsible for update notifications. It will check for updates with caching time of 1h using 'update-notifier' library and will print instructions for updating via NPM as well as updating as an executable binary. Instructions differ depending on OS.

Example for macos:

<img width="770" alt="screen shot 2018-02-12 at 15 35 23" src="https://user-images.githubusercontent.com/17809581/36090393-747fe64e-100a-11e8-9225-a94754e7591a.png">
