### PR TITLE
Automation of npm/yarn installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,16 @@ matrix:
     env: TEST=true
     sudo: required
   - os: linux
-    node_js: ['7', '9']
+    node_js:
+      - '7'
+      - '9'
     env: TEST=false
     sudo: required
   - os: osx
-    node_js: ['7', '8', '9']
+    node_js:
+      - '7'
+      - '8'
+      - '9'
     env: TEST=false
 install: if $TEST; then npm install; else echo 'skipping this script...'; fi
 script: if $TEST; then npm test; else echo 'skipping this script...'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
     env: TEST=false
 install: if $TEST; then npm install; else echo 'skipping this script...'; fi
 script: if $TEST; then npm test; else echo 'skipping this script...'; fi
-after_success:
-  - chmod ugo+x test-script.sh
-  - ./test-script.sh
 before_deploy: npm run pack
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     env: TEST=false
 install: if $TEST; then npm install; else echo 'skipping this script...'; fi
 script: if $TEST; then npm test; else echo 'skipping this script...'; fi
+after_success:
+  - chmod ugo+x test-script.sh
+  - ./test-script.sh
 before_deploy: npm run pack
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: node_js
-node_js:
-- '8'
-install:
-- npm install
-script: npm test
+matrix:
+  include:
+  - os: linux
+    node_js: '8'
+    env: TEST=true
+    sudo: required
+  - os: linux
+    node_js: ['7', '9']
+    env: TEST=false
+    sudo: required
+  - os: osx
+    node_js: ['7', '8', '9']
+    env: TEST=false
+install: if $TEST; then npm install; else echo 'skipping this script...'; fi
+script: if $TEST; then npm test; else echo 'skipping this script...'; fi
 before_deploy: npm run pack
 deploy:
   - provider: releases
@@ -20,3 +30,6 @@ deploy:
       secure: "riGRy8fqyJPXeTJulBENhxLLktvVimqTlyrjckdifenI8q0vxbTvw4fRep3fKQqgNFrh0dccIagtPO8RSuf0Se9dK+M6mBM2dc8W6t84i0jg+EDoavvhgHlVfXFNEx50lWz2H1EZH4I9MvFbAiXQm7svhaXSMwudzdlHFq/K+0xjDkVgnv4AWOnkezf8XqyOmBfVPcS6mvfEMZgtQPR41eaFM7GZ1hAwOZnOwLSTRMljBiDlBSKp89ahNsmoDua3JMZ8/5s5pp1fBzlHJx6knNF9lSTjXQtJEd1ZGZljdyjIawwCdohzcR37P6iRlCLVAOGKrbeFMUnprUk23HFg3eD86cUtly+jdZd7YqBTSBQ4m9r+3G5YKbUdCbavC0pnc3/cKwP3tYRnLN5PPxo9pTypHwvVzADgG4XBnvXsE07k8F+QBdIJce7JpM1QjDi5xiqJyOEW1YIpVnxOBtO6qc/w+cmlZzcBcdbOfss0+mEU0WHJFj+FE8jDGtt3TJK9PvkV5EKo0KtDGmZVrOeW63CJ3SE47jOcS0GwtxdlSzTsKK9Ic3b9s1pHAoqHy0n/PJEXAJ6NcS0MyeHPPwg1NWWQMIXEt1JQf6iXdcWVVCZBBXShdX4KUUQLkOHXSNv1vIKgE/5UP3bjJ+FHazLQjPjquMIRuGmy6yAwD/GaaLI="
     on:
       tags: true
+after_deploy:
+  - chmod ugo+x test-script.sh
+  - ./test-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,21 @@ matrix:
     env: TEST=true
     sudo: required
   - os: linux
-    node_js:
-      - '7'
-      - '9'
+    node_js: '7'
+    env: TEST=false
+    sudo: required
+  - os: linux
+    node_js: '9'
     env: TEST=false
     sudo: required
   - os: osx
-    node_js:
-      - '7'
-      - '8'
-      - '9'
+    node_js: '7'
+    env: TEST=false
+  - os: osx
+    node_js: '8'
+    env: TEST=false
+  - os: osx
+    node_js: '9'
     env: TEST=false
 install: if $TEST; then npm install; else echo 'skipping this script...'; fi
 script: if $TEST; then npm test; else echo 'skipping this script...'; fi

--- a/test-script.sh
+++ b/test-script.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ev
+echo '>>> Now running shell script...'
+npm i -g data-cli
+data --version
+data help
+data info https://datahub.io/core/finance-vix
+
+echo '>>> Install data-cli with yarn...'
+npm uninstall -g data-cli
+if [ $(uname) = 'Darwin' ]; then
+  brew install yarn
+else
+  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  sudo apt-get update && sudo apt-get install yarn
+fi
+
+export PATH="$(yarn global bin):$PATH"
+yarn global add data-cli
+data --version
+data info https://datahub.io/core/finance-vix


### PR DESCRIPTION
This PR for automation of the CLI tool testing when it's installed via NPM or yarn:

- refactored `.travis.yaml` so it uses Linux and MacOS with node versions 7, 8 and 9 to test the CLI tool
  - it only runs after deployment and doesn't run regular tests
- added `test-script.sh` shell script for handling all those tests