### PR TITLE
[data-push][xs]: error message when pushing inlined dataset since we …

### DIFF
--- a/bin/data-push.js
+++ b/bin/data-push.js
@@ -75,7 +75,7 @@ Promise.resolve().then(async () => {
       dataset = await prepareDatasetFromFile(filePath)
     }
     
-    dataset._resources.forEach(resource => {
+    dataset.resources.forEach(resource => {
       if (resource.constructor.name === 'FileInline') {
         throw new Error('Unfortunately, we do not support inlined datasets')
       }

--- a/bin/data-push.js
+++ b/bin/data-push.js
@@ -76,8 +76,9 @@ Promise.resolve().then(async () => {
     }
     
     dataset._resources.forEach(resource => {
-      if (resource.constructor.name === 'FileInline')
+      if (resource.constructor.name === 'FileInline') {
         throw new Error('Unfortunately, we do not support inlined datasets')
+      }
     })
     
     stopSpinner = wait('Commencing push ...')

--- a/bin/data-push.js
+++ b/bin/data-push.js
@@ -74,6 +74,12 @@ Promise.resolve().then(async () => {
     } else {
       dataset = await prepareDatasetFromFile(filePath)
     }
+    
+    dataset._resources.forEach(resource => {
+      if (resource.constructor.name === 'FileInline')
+        throw new Error('Unfortunately, we do not support inlined datasets')
+    })
+    
     stopSpinner = wait('Commencing push ...')
 
     const datahubConfigs = {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -127,13 +127,6 @@ test('info command with a dataset from DataHub', async t => {
   t.true(stdout[0].includes('CBOE Volatility Index (VIX)'))
 })
 
-test('push command with a inlined dataset', async t => {
-  const identifier = 'test/fixtures/test-data/packages/inlined-data'
-  const result = await runcli('push', identifier)
-  const stdout = result.stdout.split('\n')
-  t.true(stdout[0].includes('Unfortunately, we do not support inlined datasets'))
-})
-
 test('validate command - basic dataset', async t => {
   const path_ = 'test/fixtures/finance-vix/'
   const result = await runcli('validate', path_)

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -127,7 +127,7 @@ test('info command with a dataset from DataHub', async t => {
   t.true(stdout[0].includes('CBOE Volatility Index (VIX)'))
 })
 
-test.only('push command with a inlined dataset', async t => {
+test('push command with a inlined dataset', async t => {
   const identifier = 'test/fixtures/test-data/packages/inlined-data'
   const result = await runcli('push', identifier)
   const stdout = result.stdout.split('\n')

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -127,6 +127,13 @@ test('info command with a dataset from DataHub', async t => {
   t.true(stdout[0].includes('CBOE Volatility Index (VIX)'))
 })
 
+test.only('push command with a inlined dataset', async t => {
+  const identifier = 'test/fixtures/test-data/packages/inlined-data'
+  const result = await runcli('push', identifier)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout[0].includes('Unfortunately, we do not support inlined datasets'))
+})
+
 test('validate command - basic dataset', async t => {
   const path_ = 'test/fixtures/finance-vix/'
   const result = await runcli('validate', path_)


### PR DESCRIPTION
* Refactored `data-push.js`, now if someone tries to push inlined dataset, it will throw a human-readable error message `> Error! Unfortunately, we do not support inlined datasets`