### PR TITLE
"get" private datasets

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -38,7 +38,7 @@ const runcli = (...args) => {
 
 
 
-test.after('cleanup', t => {  
+test.after('cleanup', t => {
   let deleteFolderRecursive = (path) => {
     if (fs.existsSync(path)) {
       fs.readdirSync(path).forEach((file, index) => {
@@ -58,30 +58,7 @@ test.after('cleanup', t => {
   deleteFolderRecursive('test/big-dataset-10mb')
   fs.unlinkSync('sample.csv')
   fs.unlinkSync('sample-1-sheet.xls')
-  
-})
 
-test('get command with dataset', async t => {
-  const identifier = 'test/fixtures/finance-vix'
-  const result = await runcli('get', identifier)
-  const stdout = result.stdout.split('\n')
-  t.true(stdout[0].includes('Time elapsed:'))
-  t.true(stdout[1].includes('Dataset/file is saved in "finance-vix"'))
-})
-
-test('get command with file', async t => {
-  const identifier = 'test/fixtures/sample.csv'
-  const result = await runcli('get', identifier)
-  const stdout = result.stdout.split('\n')
-  t.true(stdout[0].includes('Time elapsed:'))
-  t.true(stdout[1].includes('Dataset/file is saved in "sample.csv"'))
-})
-
-test('runs init command with data input', async t => {
-  const cliPath = path.join(__dirname, '../bin/data-init.js')
-  const result = await run([cliPath], ['my-datapackage', ENTER])
-  t.true(result.includes('? Enter Data Package name (scratchpad)'))
-  t.true(result.includes('my-datapackage'))
 })
 
 test('"data -v --version" prints version', async t => {
@@ -109,6 +86,25 @@ test('"data help" prints help message', async t => {
   t.true(stdout[1].includes('❒ data [options] <command> <args>'))
 })
 
+
+// =======================================
+// DATA-CLI GET
+
+test('get command with local dataset', async t => {
+  const identifier = 'test/fixtures/finance-vix'
+  const result = await runcli('get', identifier)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout[0].includes('Time elapsed:'))
+  t.true(stdout[1].includes('Dataset/file is saved in "finance-vix"'))
+})
+
+test('get command with local file', async t => {
+  const identifier = 'test/fixtures/sample.csv'
+  const result = await runcli('get', identifier)
+  const stdout = result.stdout.split('\n')
+  t.true(stdout[0].includes('Time elapsed:'))
+  t.true(stdout[1].includes('Dataset/file is saved in "sample.csv"'))
+})
 
 // QA tests [Get: Small dataset from DataHub]
 
@@ -161,6 +157,13 @@ test('get command with excel file', async t => {
 
 // =======================================
 // CLI commands: validate, cat, info, init
+
+test('runs init command with data input', async t => {
+  const cliPath = path.join(__dirname, '../bin/data-init.js')
+  const result = await run([cliPath], ['my-datapackage', ENTER])
+  t.true(result.includes('? Enter Data Package name (scratchpad)'))
+  t.true(result.includes('my-datapackage'))
+})
 
 // QA tests [Info: basic dataset]
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -56,6 +56,7 @@ test.after('cleanup', t => {
   deleteFolderRecursive('test/small-dataset-100kb')
   deleteFolderRecursive('test/medium-dataset-1mb')
   deleteFolderRecursive('test/big-dataset-10mb')
+  deleteFolderRecursive('test/private-cli-test')
   fs.unlinkSync('sample.csv')
   fs.unlinkSync('sample-1-sheet.xls')
 
@@ -114,6 +115,7 @@ test('get command with small dataset from DataHub', async t => {
   const stdout = result.stdout.split('\n')
   t.true(stdout[0].includes('Time elapsed:'))
   t.true(stdout[1].includes('Dataset/file is saved in "test/small-dataset-100kb"'))
+  // t.true(fs.)
 })
 
 // end of [Get: Small dataset from DataHub]
@@ -153,6 +155,25 @@ test('get command with excel file', async t => {
 })
 
 // end of [Get: get excel file]
+
+// QA tests [Get: get private dataset]
+
+test('get command with private dataset', async t => {
+  const identifier = 'https://datahub.io/test/private-cli-test'
+  // Note that token for test user is set in env var. First we pass wrong token
+  // as an argument and expect 404 or 403:
+  const token = 'non-owner-token'
+  let result = await runcli('get', identifier, `--token=${token}`)
+  let stdout = result.stdout.split('\n')
+  t.true(stdout[0].includes('Not Found or Forbidden'))
+
+  // Now use correct token from env var:
+  result = await runcli('get', identifier)
+  stdout = result.stdout.split('\n')
+  t.true(stdout[0].includes('Time elapsed:'))
+  t.true(stdout[1].includes('Dataset/file is saved in "test/private-cli-test"'))
+  t.true(fs.existsSync('test/private-cli-test/datapackage.json'))
+})
 
 
 // =======================================


### PR DESCRIPTION
Now "get" command works with private datasets:

When an identifier is datahub type, we don't load Dataset object but use frontend API for getting "zipped" version of a dataset. This way we delegate handling of private datasets to the frontend, where it's already implemented.

Algorithm:

1. identify it's DataHub dataset
2. construct URL for "zipped" resource: `https://datahub.io/{owner}/{dataset}/r/{dataset}_zip.zip`
3. read token from config and include it as params in the URL for "zipped" resource ^
4. proceed as before