### PR TITLE
[data-info][xs]: data info throws error on invalid url - refs #303

### DIFF
--- a/bin/data-info.js
+++ b/bin/data-info.js
@@ -39,6 +39,8 @@ Promise.resolve().then(async () => {
       console.log(customMarked(out))
     } else {
       const file = data.File.load(fileOrDatasetIdentifier, {format: argv.format})
+      // Use stream() for checking invalid url
+      await file.stream()
       const knownTabularFormats = ['csv', 'tsv', 'dsv']
       if (knownTabularFormats.includes(file.descriptor.format)) {
         await file.addSchema()


### PR DESCRIPTION
Since we need to handle the cases when url is invalid, we can check using `stream` method. So, instead of printing `File descriptor`, it will throw an error:
```
Meirans-MBP:data.js Zhiyenbayev_mirza$ data info https://gsdasdasdad.dsasdasd
> Error! Connection error: request to https://gsdasdasdad.dsasdasd failed, reason: getaddrinfo ENOTFOUND gsdasdasdad.dsasdasd gsdasdasdad.dsasdasd:443
```

