### PR TITLE
Sheet option for 'cat' command

### DIFF
--- a/bin/data-cat.js
+++ b/bin/data-cat.js
@@ -45,11 +45,11 @@ const writersDatabase = {
   html: writers.html
 }
 
-const dumpIt = async (res) => {
+const dumpIt = async (res, {sheet}={}) => {
   let stream
   if (outFormat in writersDatabase) {
     try {
-      stream = await writersDatabase[outFormat](res)
+      stream = await writersDatabase[outFormat](res, {sheet})
     } catch (err) {
       if (isUrl(argv._[0])) {
         error('Provided URL is invalid')
@@ -75,8 +75,12 @@ const dumpIt = async (res) => {
 if (pathParts.name === '_' || (!pathParts.name && process.stdin.constructor.name === 'Socket')) {
   dumpIt(process.stdin)
 } else if (pathParts.name) {
+  // Check both 'sheet' and 'sheets' args as users can use both of them:
+  let sheet = argv.sheet || argv.sheets
+  // Check if it can be coerced to integer, if so we assume it's sheet index:
+  sheet = !!parseInt(sheet) ? parseInt(sheet) - 1 : sheet
   const res = File.load(argv._[0], {format: argv.format})
-  dumpIt(res)
+  dumpIt(res, {sheet})
 } else {
   info('No input is provided. Please, run "data cat --help" for usage information.')
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -38,7 +38,7 @@ const runcli = (...args) => {
 
 
 
-test.after('cleanup', t => {
+test.after.always('cleanup', t => {
   let deleteFolderRecursive = (path) => {
     if (fs.existsSync(path)) {
       fs.readdirSync(path).forEach((file, index) => {
@@ -169,7 +169,7 @@ test('get command with private dataset', async t => {
   const token = 'non-owner-token'
   let result = await runcli('get', identifier, `--token=${token}`)
   let stdout = result.stdout.split('\n')
-  t.true(stdout[0].includes('Not Found or Forbidden'))
+  t.true(stdout[0].includes('> Error! 404: Not Found. Requested URL'))
 
   // Now use correct token from env var:
   result = await runcli('get', identifier)
@@ -546,7 +546,7 @@ test('cat command - URL that returns 404', async t => {
   const results = await runcli('cat', url_)
   const stdout = results.stdout.split('\n')
   t.is(stdout[0], '> Error! Provided URL is invalid')
-  t.is(stdout[1], '> Error! Not Found')
+  t.is(stdout[1], '> Error! 404: Not Found. Requested URL: https://raw.githubusercontent.com/frictionlessdata/test-data/master/files/other/sampl.csv')
 })
 
 // end of [Cat: basic csv]
@@ -585,7 +585,7 @@ test('cat command - files with different separator', async t => {
 
 // QA test [Cat: different encodings]
 
-test.skip('cat command - different encodings', async t => {
+test.failing('cat command - different encodings', async t => {
   const path_ = 'test/fixtures/test-data/files/csv/encodings/iso8859.csv'
   let results = await runcli('cat', path_)
   let stdout = results.stdout.split('\n')

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -627,6 +627,24 @@ test('cat command - remote excel file', async t => {
   t.true(stdout[1].includes('number'))
 })
 
+test('cat command - specific excel sheet', async t => {
+  const path_ = 'test/fixtures/test-data/files/excel/sample-2-sheets.xlsx'
+  // With sheet name:
+  let results = await runcli('cat', path_, '--sheet=Sheet2')
+  let stdout = results.stdout.split('\n')
+  let hasHeaderFrom2ndSheet = stdout.find(item => item.includes('header4'))
+  t.truthy(hasHeaderFrom2ndSheet)
+  // With sheet index:
+  results = await runcli('cat', path_, '--sheet=2')
+  stdout = results.stdout.split('\n')
+  hasHeaderFrom2ndSheet = stdout.find(item => item.includes('header4'))
+  t.truthy(hasHeaderFrom2ndSheet)
+  // When sheet doesn't exist:
+  results = await runcli('cat', path_, '--sheet=3')
+  stdout = results.stdout.split('\n')
+  t.is(stdout[0], '> Error! Input source is empty or doesn\'t exist.')
+})
+
 module.exports = {
   runcli
 }


### PR DESCRIPTION
This PR allows users to 'cat' excel files with sheet option (index or name). E.g., you can try:

* `data cat my.xlsx` - prints the first sheet to stdout
* `data cat my.xlsx --sheet 2` - prints the second sheet to stdout (using sheet index)
* `data cat my.xlsx --sheet mysheet` - prints the sheet named 'mysheet' to stdout
* `data cat my.xlsx out.csv --sheet 2` - saves the second sheet to `out.csv` file
  * same for markdown, html and excel files (e.g., you want to save the second sheet in the separate excel file)