### PR TITLE
fix/MaxListenersExceededWarning

### DIFF
--- a/bin/data-validate.js
+++ b/bin/data-validate.js
@@ -8,6 +8,11 @@ const jsonlint = require('jsonlint')
 const {validate} = require('datahub-client').validate
 const {Dataset} = require('data.js')
 
+// increase MaxListenersExceededWarning level for cases when the remote dataset has a lot of resources,
+// to avoid: Warning: Possible EventEmitter memory leak detected. X end listeners added.
+// ~11 requests is required to validate remote 1 tabular resource, so I set a limit to match a dataset with 10 files.
+require('events').EventEmitter.defaultMaxListeners = 120;
+
 // Ours
 const {customMarked} = require('../lib/utils/tools')
 const {error} = require('../lib/utils/error')


### PR DESCRIPTION
Issue: https://github.com/datahq/datahub-qa/issues/118

This fix changes the EventEmitter warning level, and user can `data validate` remote resources with up to 10 files without noise warnings.

You could see the problem, if try to validate a remote dataset with many resources 
(the warnings are suppressed in the binary version of `data-cli`, so use one from `npm i data-cli`):
`data validate http://datahub.io/core/population-growth-estimates-and-projections`
