### PR TITLE
Now 'get' command works with datahub datasets that have trailing slash

### DIFF
--- a/bin/data-get.js
+++ b/bin/data-get.js
@@ -62,6 +62,10 @@ const run = async () => {
       await Promise.all(myPromises)
 
     } else if (parsedIdentifier.type === "datahub") {
+      // Remove trailing slash:
+      if(identifier.substr(-1) === '/' && identifier.length > 1) {
+        identifier = identifier.slice(0, identifier.length - 1)
+      }
       // Try to guess owner and dataset name here. We're not loading Dataset object
       // because we want to handle private datasets as well:
       const idParts = identifier.split('/')

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -114,7 +114,7 @@ test('get command with local file', async t => {
 // QA tests [Get: Small dataset from DataHub]
 
 test('get command with small dataset from DataHub', async t => {
-  const identifier = 'https://datahub.io/test/small-dataset-100kb'
+  const identifier = 'https://datahub.io/test/small-dataset-100kb/'
   const result = await runcli('get', identifier)
   const stdout = result.stdout.split('\n')
   t.true(stdout[0].includes('Time elapsed:'))
@@ -178,6 +178,8 @@ test('get command with private dataset', async t => {
   t.true(stdout[1].includes('Dataset/file is saved in "test/private-cli-test"'))
   t.true(fs.existsSync('test/private-cli-test/datapackage.json'))
 })
+
+// end of QA tests [Get: get private dataset]
 
 
 // =======================================


### PR DESCRIPTION
E.g., this now works: `data get https://datahub.io/core/finance-vix/`