### PR TITLE
[push] --published option synonyms added: --publish, --public

### DIFF
--- a/bin/data-push.js
+++ b/bin/data-push.js
@@ -91,7 +91,7 @@ Promise.resolve().then(async () => {
       owner: config.get('profile') ? config.get('profile').username : config.get('username')
     }
     let findability = 'unlisted'
-    if (argv.published) {
+    if (argv.published || argv.publish || argv.public) {
       findability = 'published'
     }
     if (argv.private) {

--- a/docs/push.md
+++ b/docs/push.md
@@ -30,9 +30,8 @@ This options define the dataset visibility on the DataHub.io site:
                            You will see the dataset in the search results.
                            Everybody can access the dataset by the URL link.
 
-  --published,             Everybody can see the dataset in the search results.
-  --publish,               Everybody can access the dataset by the URL link.
-  --public
+  --public                 Everybody can see the dataset in the search results.
+                           Everybody can access the dataset by the URL link.
 
   --private                Other users cannot access the dataset.
                            Other users will not see the dataset in the search results.

--- a/docs/push.md
+++ b/docs/push.md
@@ -12,8 +12,6 @@
   
   -i, --interactive        Enable interactive mode. Useful when pushing a single file.
   
-  --published              Make a dataset "published" so it is public on the website (default is "unlisted").
-  
   --schedule               Setup a schedule so the DataHub will automatically re-import the remote file on 
                            a regular basis. E.g., `every 90s`, `every 5m`, `every 2d`. The number is always 
                            an integer, selector is `s/m/h/d/w` (second -> week) and you can’t schedule for 
@@ -23,6 +21,22 @@
                            the first sheet is processed. You can use `--sheets=all` option to push "all" sheets.
                            You also can list sheet numbers, e.g., `--sheets=1,2`. If you wanted to push only 
                            the second sheet, you would do `--sheets=2`. Sheet number starts from 1.
+
+### findability options:
+
+This options define the dataset visibility on the DataHub.io site:
+
+  --unlisted (default)     Other users will not see the dataset in the search results.
+                           You will see the dataset in the search results.
+                           Everybody can access the dataset by the URL link.
+
+  --published,             Everybody can see the dataset in the search results.
+  --publish,               Everybody can access the dataset by the URL link.
+  --public
+
+  --private                Other users cannot access the dataset.
+                           Other users will not see the dataset in the search results.
+                           You will see the dataset in the search results.
 
 ## Examples:
 

--- a/test/push/push.test.js
+++ b/test/push/push.test.js
@@ -28,13 +28,10 @@ test.serial('push command succeeds with regular CSV file', async t => {
 
 test.serial('push --public', async t => {
   const path_ = 'test/fixtures/test-data/files/csv/separators/comma.csv'
-  const args = '--public --name=findablility_test --debug' // --debug is to see the flow-spec
-  const result = await runcli('push', path_, args)
-  const stdout = result.stdout.split('\n')
+  const args = ['--name=public-test', '--public', '--debug']
+  const result = await runcli('push', path_, ...args)
 
-  /** before we used 'published' keyword, but it could be 'public' in the future */
-  const findabilityIsPublished = stdout.find(item => item.includes('"findability": "published"'))
-  t.truthy(findabilityIsPublished)
+  t.truthy(result.stdout.includes('"findability": "published"'))
 })
 
 // QA tests [pushing valid dataset from path]

--- a/test/push/push.test.js
+++ b/test/push/push.test.js
@@ -26,6 +26,17 @@ test.serial('push command succeeds with regular CSV file', async t => {
 
 // end of [pushing valid CSV file]
 
+test.serial('push --public', async t => {
+  const path_ = 'test/fixtures/test-data/files/csv/separators/comma.csv'
+  const args = '--public --name=findablility_test --debug' // --debug is to see the flow-spec
+  const result = await runcli('push', path_, args)
+  const stdout = result.stdout.split('\n')
+
+  /** before we used 'published' keyword, but it could be 'public' in the future */
+  const findabilityIsPublished = stdout.find(item => item.includes('"findability": "published"'))
+  t.truthy(findabilityIsPublished)
+})
+
 // QA tests [pushing valid dataset from path]
 
 test.serial('push command succeeds for valid dataset', async t => {


### PR DESCRIPTION
* --published, --publish, --public  keywords are now synonyms.
* Help doc is updated.
* We send **"findability": "published"** on the server in all three cases.

https://github.com/datahq/datahub-qa/issues/193
https://github.com/datahq/data-cli/issues/326